### PR TITLE
[DEV-921] Modify regex used by the Message class to detect a command

### DIFF
--- a/lib/lita/message.rb
+++ b/lib/lita/message.rb
@@ -44,9 +44,9 @@ module Lita
       name_pattern = "@?#{Regexp.escape(@robot.mention_name)}[:,]?\\s+"
       alias_pattern = "#{Regexp.escape(@robot.alias)}\\s*" if @robot.alias
       command_regex = if alias_pattern
-        /^\s*(?:#{name_pattern}|#{alias_pattern})/i
+        /\A\s*(?:#{name_pattern}|#{alias_pattern})/i
       else
-        /^\s*#{name_pattern}/i
+        /\A\s*#{name_pattern}/i
       end
 
       @command = !!@body.sub!(command_regex, "")

--- a/spec/lita/message_spec.rb
+++ b/spec/lita/message_spec.rb
@@ -111,6 +111,14 @@ describe Lita::Message do
       end
     end
 
+    context "when a multi-line message contains a command past the beginning of the message" do
+      subject { described_class.new(robot, "```\n#{robot.mention_name}: hello\n```", source) }
+
+      it "is false" do
+        expect(subject).not_to be_a_command
+      end
+    end
+
     it "is false when the message is not addressed to the Robot" do
       expect(subject).not_to be_a_command
     end


### PR DESCRIPTION
See https://github.com/litaio/lita/pull/187

The previous regex allowed each line beginning with Lita's mention name
or alias in a multi-line message to be interpreted as a command, which
is problematic for commands deliberately enclosed in code blockquotes
like "\n!foo\n". With this change, Lita will check for the
presence of a command once per message instead of once per line.