### PR TITLE
Trigger :message_received every time robot.receive is called

### DIFF
--- a/lib/lita/robot.rb
+++ b/lib/lita/robot.rb
@@ -63,6 +63,8 @@ module Lita
     # @param message [Lita::Message] The incoming message.
     # @return [void]
     def receive(message)
+      trigger(:message_received, message: message)
+
       matched = handlers.map do |handler|
         next unless handler.respond_to?(:dispatch)
 

--- a/spec/lita/handler/chat_router_spec.rb
+++ b/spec/lita/handler/chat_router_spec.rb
@@ -111,6 +111,7 @@ describe handler, lita_handler: true do
     end
 
     it "triggers a message_dispatched event" do
+      expect(robot).to receive(:trigger).with(:message_received, anything)
       expect(robot).to receive(:trigger).with(:message_dispatched, anything)
       send_message("message")
     end


### PR DESCRIPTION
lita-google-translate previously routed all non-command messages to their respective ambient message methods, which meant that `:unhandled_message` was never triggered, interfering with invalid command handling and logging.

The equivalent PR on litaio/lita:master has been merged: https://github.com/litaio/lita/pull/188
Example of usage on lita-google-translate: https://github.com/tristaneuan/lita-google-translate/pull/1